### PR TITLE
Gitignore should ignore node_modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dashboard/*
 databases/*
 public/*
 tmp/*
+node_modules/*
+


### PR DESCRIPTION
node_modules should not be maintained by git.  (Creates a ton of unwanted changes when you do an npm-install).